### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ the [Sass](http://sass-lang.com/) CSS3 extension which adds nested rules, variab
 
 * the most popular and robust Javascript libraries for application architecture ([Backbone.js](http://documentcloud.github.com/backbone/)), view templating ([Underscore](http://documentcloud.github.com/underscore/#template)), and day-to-day coding ([jQuery](http://jquery.com/))
 
-#Requirements
+# Requirements
 
 To use this tools you need to have the following installed:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
